### PR TITLE
Adding option to disable deployment of the certificates to the managed nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ This does **not** affect users including the role with variables defined via `ex
 | `crt_local_dest_path_mode`                                  | Mode of `{{ crt_local_dest_path }}`                                                                       |
 | `crt_quiet_assert`                                          | Whether to quiet assert                                                                                   |
 | `crt_remove_temporary_local_certificates`                   | Whether to remove locally stored temporary certificates (will break idempotency when set to `true`)       |
+| `crt_deploy_certificates`                                   | Whether to deploy certificates to the managed node (don't forget to turn off to remove local files :>)    |
 
 #### Variable to default variable
 | variable                                                    | default variable                                                                                          |
@@ -222,6 +223,7 @@ This does **not** affect users including the role with variables defined via `ex
 | `crt_local_dest_path_mode`                                  | `_def_crt_local_dest_path_mode`                                                                           |
 | `crt_quiet_assert`                                          | `_def_crt_quiet_assert`                                                                                   |
 | `crt_remove_temporary_local_certificates`                   | `_def_crt_remove_temporary_local_certificates`                                                            |
+| `crt_deploy_certificates`                                   | `_def_crt_deploy_certificates`                                                                            |
 
 #### Default variable to default value and requirement
 | default variable                                            | default value                                                                                  | required |
@@ -232,6 +234,7 @@ This does **not** affect users including the role with variables defined via `ex
 | `_def_crt_local_dest_path_mode`                             | `0700`                                                                                         | false    |
 | `_def_crt_quiet_assert`                                     | `true`                                                                                         | false    |
 | `_def_crt_remove_temporary_local_certificates`              | `true`                                                                                         | false    |
+| `_def_crt_deploy_certificates`                              | `true`                                                                                         | false    |
 
 ## Private key infrastructure (PKI) host
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -136,6 +136,9 @@ _def_crt_pki_host_remote_port: 22
 # whether to remove locally stored temporary certificates (will break idempotency)
 _def_crt_remove_temporary_local_certificates: true
 
+# whether to deploy the certificate to the managed node
+_def_crt_deploy_certificates: true
+
 #
 # Managed node certificate paths
 #

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -10,6 +10,7 @@
 
     success_msg: "Variable '{{ _var }}' defined properly - value: '{{ lookup('ansible.builtin.vars', _var) }}'"
     fail_msg: "Variable '{{ _var }}' failed to validate"
+  quiet: '{{ _crt_quiet_assert | default(false) }}'
   loop:
     - '_crt_ca_fetch_ca_cert'
     - '_crt_ca_fetch_ca_chain_cert'
@@ -18,6 +19,7 @@
     - '_crt_force_priv_key_generation'
     - '_crt_quiet_assert'
     - '_crt_remove_temporary_local_certificates'
+    - '_crt_deploy_certificates'
   loop_control:
     loop_var: '_var'
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,9 @@
 - name: 'Include tasks to transfer the certificates to the managed node'
   ansible.builtin.include_tasks:
     file: 'transfer_certs.yml'
+  when: >
+    _crt_deploy_certificates is defined
+    and _crt_deploy_certificates
 
 - name: 'Include tasks to cleanup locally stored files'
   ansible.builtin.include_tasks:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -164,6 +164,9 @@ _crt_remove_temporary_local_certificates: >-
     crt_remove_temporary_local_certificates | default(_def_crt_remove_temporary_local_certificates)
   }}
 
+# whether to deploy the certificate to the managed node
+_crt_deploy_certificates: '{{ crt_deploy_certificates | default(_def_crt_deploy_certificates) }}'
+
 #
 # Managed node certificate paths
 #


### PR DESCRIPTION
This option only makes sense when disabling the cleanup of the local temporary stored certificates (`crt_remove_temporary_local_certificates: false`).