### PR TITLE
fix!: Ensure only files of one host are removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ This does **not** affect users including the role with variables defined via `ex
 | `crt_local_dest_path_mode`                                  | Mode of `{{ crt_local_dest_path }}`                                                                       |
 | `crt_quiet_assert`                                          | Whether to quiet assert                                                                                   |
 | `crt_remove_temporary_local_certificates`                   | Whether to remove locally stored temporary certificates (will break idempotency when set to `true`)       |
+| `crt_remove_local_dest_path`                                | Whether to remove `{{ crt_local_dest_path }}`                                                             |
 | `crt_deploy_certificates`                                   | Whether to deploy certificates to the managed node (don't forget to turn off to remove local files :>)    |
 | `crt_install_prerequisite_packages`                         | Whether to install prerequisite packages. Only disable when you are sure that these are present           |
 
@@ -237,6 +238,7 @@ This does **not** affect users including the role with variables defined via `ex
 | `crt_local_dest_path_mode`                                  | `_def_crt_local_dest_path_mode`                                                                           |
 | `crt_quiet_assert`                                          | `_def_crt_quiet_assert`                                                                                   |
 | `crt_remove_temporary_local_certificates`                   | `_def_crt_remove_temporary_local_certificates`                                                            |
+| `crt_remove_local_dest_path`                                | `_def_crt_remove_local_dest_path`                                                                         |
 | `crt_deploy_certificates`                                   | `_def_crt_deploy_certificates`                                                                            |
 | `crt_install_prerequisite_packages`                         | `_def_crt_install_prerequisite_packages`                                                                  |
 
@@ -249,6 +251,7 @@ This does **not** affect users including the role with variables defined via `ex
 | `_def_crt_local_dest_path_mode`                             | `0700`                                                                                         | false    |
 | `_def_crt_quiet_assert`                                     | `true`                                                                                         | false    |
 | `_def_crt_remove_temporary_local_certificates`              | `true`                                                                                         | false    |
+| `_def_crt_remove_local_dest_path`                           | `false`                                                                                        | false    |
 | `_def_crt_deploy_certificates`                              | `true`                                                                                         | false    |
 | `_def_crt_install_prerequisite_packages`                    | `true`                                                                                         | false    |
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -140,7 +140,11 @@ _def_crt_quiet_assert: true
 _def_crt_pki_host_remote_port: 22
 
 # whether to remove locally stored temporary certificates (will break idempotency)
+# this will remove only the files and the directory for one specific host
 _def_crt_remove_temporary_local_certificates: true
+
+# whether to remove crt_local_dest_path completely
+_def_crt_remove_local_dest_path: false
 
 # whether to deploy the certificate to the managed node
 _def_crt_deploy_certificates: true

--- a/tasks/cleanup.yml
+++ b/tasks/cleanup.yml
@@ -2,7 +2,17 @@
 - name: 'cleanup | Ensure locally stored files are removed'
   ansible.builtin.file:
     state: 'absent'
+    path: '{{ _crt_local_dest_path }}/{{ inventory_hostname }}'
+  delegate_to: 'localhost'
+  become: true
+
+- name: 'cleanup | Ensure parent directory of fetched certificates is removed: {{ _crt_local_dest_path }}'
+  ansible.builtin.file:
+    state: 'absent'
     path: '{{ _crt_local_dest_path }}'
   delegate_to: 'localhost'
   become: true
+  when:
+    - '_crt_remove_local_dest_path is defined'
+    - '_crt_remove_local_dest_path'
 ...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -174,9 +174,16 @@ _crt_quiet_assert: '{{ crt_quiet_assert | default(_def_crt_quiet_assert) }}'
 _crt_pki_host_remote_port: '{{ crt_pki_host_remote_port | default(_def_crt_pki_host_remote_port) }}'
 
 # whether to remove locally stored temporary certificates (will break idempotency)
+# this will remove only the files and the directory for one specific host
 _crt_remove_temporary_local_certificates: >-
   {{
     crt_remove_temporary_local_certificates | default(_def_crt_remove_temporary_local_certificates)
+  }}
+
+# whether to remove crt_local_dest_path completely
+_crt_remove_local_dest_path: >-
+  {{
+    crt_remove_local_dest_path | default(_def_crt_remove_local_dest_path)
   }}
 
 # whether to deploy the certificate to the managed node


### PR DESCRIPTION
Adding a new variable crt_remove_local_dest_path which defaults to false (breaking change) as the role previously removed all files in crt_local_dest_path instead of
crt_local_dest_path/<inventory_hostname>